### PR TITLE
feat(auth): implement email, Google, and Kakao login with user session and logout (Flutter + Supabase)

### DIFF
--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -38,7 +38,6 @@ class AuthService extends ChangeNotifier {
     });
   }
 
-  // 이메일 회원가입
   Future<String?> signUpWithEmail({
     required String email,
     required String password,
@@ -58,7 +57,6 @@ class AuthService extends ChangeNotifier {
     }
   }
 
-  // 이메일 로그인
   Future<String?> signInWithEmail({
     required String email,
     required String password,
@@ -76,13 +74,16 @@ class AuthService extends ChangeNotifier {
     }
   }
 
-  // 카카오 로그인
   Future<String?> signInWithKakao() async {
     try {
       await _supabase.auth.signInWithOAuth(
         OAuthProvider.kakao,
         redirectTo: kIsWeb ? null : 'io.supabase.lit_goal://login-callback',
+        authScreenLaunchMode: kIsWeb
+            ? LaunchMode.platformDefault
+            : LaunchMode.externalApplication,
       );
+
       return null;
     } on AuthException catch (error) {
       return error.message;
@@ -91,7 +92,6 @@ class AuthService extends ChangeNotifier {
     }
   }
 
-  // 구글 로그인
   Future<String?> signInWithGoogle() async {
     try {
       await _supabase.auth.signInWithOAuth(
@@ -106,7 +106,6 @@ class AuthService extends ChangeNotifier {
     }
   }
 
-  // 로그아웃
   Future<String?> signOut() async {
     try {
       await _supabase.auth.signOut();
@@ -118,7 +117,6 @@ class AuthService extends ChangeNotifier {
     }
   }
 
-  // 비밀번호 재설정 이메일 전송
   Future<String?> resetPassword(String email) async {
     try {
       await _supabase.auth.resetPasswordForEmail(

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -1,0 +1,135 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:flutter/foundation.dart';
+import '../../domain/models/user_model.dart';
+
+class AuthService extends ChangeNotifier {
+  final SupabaseClient _supabase = Supabase.instance.client;
+  UserModel? _currentUser;
+
+  UserModel? get currentUser => _currentUser;
+
+  AuthService() {
+    _init();
+  }
+
+  void _init() {
+    _currentUser = _supabase.auth.currentUser != null
+        ? UserModel.fromUser(_supabase.auth.currentUser!)
+        : null;
+
+    _supabase.auth.onAuthStateChange.listen((data) {
+      final AuthChangeEvent event = data.event;
+      final Session? session = data.session;
+
+      switch (event) {
+        case AuthChangeEvent.signedIn:
+          if (session?.user != null) {
+            _currentUser = UserModel.fromUser(session!.user);
+            notifyListeners();
+          }
+          break;
+        case AuthChangeEvent.signedOut:
+          _currentUser = null;
+          notifyListeners();
+          break;
+        default:
+          break;
+      }
+    });
+  }
+
+  // 이메일 회원가입
+  Future<String?> signUpWithEmail({
+    required String email,
+    required String password,
+    String? name,
+  }) async {
+    try {
+      final AuthResponse response = await _supabase.auth.signUp(
+        email: email,
+        password: password,
+        data: {'name': name},
+      );
+      return null;
+    } on AuthException catch (error) {
+      return error.message;
+    } catch (error) {
+      return '알 수 없는 오류가 발생했습니다.';
+    }
+  }
+
+  // 이메일 로그인
+  Future<String?> signInWithEmail({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final AuthResponse response = await _supabase.auth.signInWithPassword(
+        email: email,
+        password: password,
+      );
+      return null;
+    } on AuthException catch (error) {
+      return error.message;
+    } catch (error) {
+      return '알 수 없는 오류가 발생했습니다.';
+    }
+  }
+
+  // 카카오 로그인
+  Future<String?> signInWithKakao() async {
+    try {
+      await _supabase.auth.signInWithOAuth(
+        OAuthProvider.kakao,
+        redirectTo: kIsWeb ? null : 'io.supabase.lit_goal://login-callback',
+      );
+      return null;
+    } on AuthException catch (error) {
+      return error.message;
+    } catch (error) {
+      return '알 수 없는 오류가 발생했습니다.';
+    }
+  }
+
+  // 구글 로그인
+  Future<String?> signInWithGoogle() async {
+    try {
+      await _supabase.auth.signInWithOAuth(
+        OAuthProvider.google,
+        redirectTo: kIsWeb ? null : 'io.supabase.lit_goal://login-callback',
+      );
+      return null;
+    } on AuthException catch (error) {
+      return error.message;
+    } catch (error) {
+      return '알 수 없는 오류가 발생했습니다.';
+    }
+  }
+
+  // 로그아웃
+  Future<String?> signOut() async {
+    try {
+      await _supabase.auth.signOut();
+      return null;
+    } on AuthException catch (error) {
+      return error.message;
+    } catch (error) {
+      return '알 수 없는 오류가 발생했습니다.';
+    }
+  }
+
+  // 비밀번호 재설정 이메일 전송
+  Future<String?> resetPassword(String email) async {
+    try {
+      await _supabase.auth.resetPasswordForEmail(
+        email,
+        redirectTo: kIsWeb ? null : 'io.supabase.lit_goal://reset-callback',
+      );
+      return null;
+    } on AuthException catch (error) {
+      return error.message;
+    } catch (error) {
+      return '알 수 없는 오류가 발생했습니다.';
+    }
+  }
+}

--- a/lib/domain/models/user_model.dart
+++ b/lib/domain/models/user_model.dart
@@ -1,0 +1,53 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class UserModel {
+  final String id;
+  final String? email;
+  final String? name;
+  final String? avatarUrl;
+  final Map<String, dynamic>? metadata;
+  final DateTime? createdAt;
+  final DateTime? lastSignInAt;
+
+  UserModel({
+    required this.id,
+    this.email,
+    this.name,
+    this.avatarUrl,
+    this.metadata,
+    this.createdAt,
+    this.lastSignInAt,
+  });
+
+  factory UserModel.fromUser(User user) {
+    return UserModel(
+      id: user.id,
+      email: user.email,
+      name: user.userMetadata?['name'] as String?,
+      avatarUrl: user.userMetadata?['avatar_url'] as String?,
+      metadata: user.userMetadata,
+      createdAt: DateTime.tryParse(user.createdAt ?? ''),
+      lastSignInAt: DateTime.tryParse(user.lastSignInAt ?? ''),
+    );
+  }
+
+  UserModel copyWith({
+    String? id,
+    String? email,
+    String? name,
+    String? avatarUrl,
+    Map<String, dynamic>? metadata,
+    DateTime? createdAt,
+    DateTime? lastSignInAt,
+  }) {
+    return UserModel(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      name: name ?? this.name,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      metadata: metadata ?? this.metadata,
+      createdAt: createdAt ?? this.createdAt,
+      lastSignInAt: lastSignInAt ?? this.lastSignInAt,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:lit_goal/data/services/book_service.dart';
 import 'package:lit_goal/ui/home/view_model/home_view_model.dart';
 import 'data/services/auth_service.dart';
 import 'ui/auth/widgets/login_screen.dart';
+import 'ui/auth/widgets/my_page_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -74,7 +75,7 @@ class AuthWrapper extends StatelessWidget {
     return Consumer<AuthService>(
       builder: (context, authService, _) {
         if (authService.currentUser != null) {
-          return const HomeScreen();
+          return const MainScreen();
         }
         return const LoginScreen();
       },
@@ -96,7 +97,7 @@ class _MainScreenState extends State<MainScreen> {
   List<Widget> get _pages => [
         const HomeScreen(),
         const BookListScreen(),
-        const CalendarScreen(),
+        const MyPageScreen(),
       ];
 
   void _onItemTapped(int index) {
@@ -113,6 +114,7 @@ class _MainScreenState extends State<MainScreen> {
           body: _pages[_selectedIndex],
           bottomNavigationBar: BottomNavigationBar(
             backgroundColor: Colors.white,
+            type: BottomNavigationBarType.fixed,
             items: const [
               BottomNavigationBarItem(
                 icon: Icon(CupertinoIcons.home),
@@ -123,12 +125,13 @@ class _MainScreenState extends State<MainScreen> {
                 label: '독서 목록',
               ),
               BottomNavigationBarItem(
-                icon: Icon(CupertinoIcons.calendar),
-                label: '캘린더',
+                icon: Icon(CupertinoIcons.person),
+                label: '마이페이지',
               ),
             ],
             currentIndex: _selectedIndex,
             selectedItemColor: Colors.blue,
+            unselectedItemColor: Colors.grey, // 또는 Colors.black54 등
             onTap: (index) {
               if (!_isDropdownOpen) {
                 _onItemTapped(index);
@@ -212,13 +215,15 @@ class _MainScreenState extends State<MainScreen> {
                                   SizedBox(
                                     width: 8,
                                   ),
-                                  Text('새 독서 시작',
-                                      style: TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.w400,
-                                        color: Colors.black,
-                                        decoration: TextDecoration.none,
-                                      )),
+                                  Text(
+                                    '새 독서 시작',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w400,
+                                      color: Colors.black,
+                                      decoration: TextDecoration.none,
+                                    ),
+                                  ),
                                 ],
                               ),
                             ),
@@ -238,17 +243,22 @@ class _MainScreenState extends State<MainScreen> {
                               ),
                               child: const Row(
                                 children: [
-                                  Icon(Icons.camera_alt, color: Colors.black),
+                                  Icon(
+                                    Icons.camera_alt,
+                                    color: Colors.black,
+                                  ),
                                   SizedBox(
                                     width: 8,
                                   ),
-                                  Text('사진 추가',
-                                      style: TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.w400,
-                                        color: Colors.black,
-                                        decoration: TextDecoration.none,
-                                      )),
+                                  Text(
+                                    '사진 추가',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w400,
+                                      color: Colors.black,
+                                      decoration: TextDecoration.none,
+                                    ),
+                                  ),
                                 ],
                               ),
                             ),

--- a/lib/ui/auth/widgets/login_screen.dart
+++ b/lib/ui/auth/widgets/login_screen.dart
@@ -49,7 +49,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
     if (errorMessage != null && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(errorMessage)),
+        SnackBar(content: Text(mapAuthError(errorMessage))),
       );
     }
   }
@@ -64,9 +64,25 @@ class _LoginScreenState extends State<LoginScreen> {
 
     if (errorMessage != null && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(errorMessage)),
+        SnackBar(content: Text(mapAuthError(errorMessage))),
       );
     }
+  }
+
+  String mapAuthError(String error) {
+    if (error.contains('Invalid login credentials')) {
+      return '이메일 또는 비밀번호가 올바르지 않습니다.';
+    }
+    if (error.contains('Email not confirmed')) {
+      return '이메일 인증이 완료되지 않았습니다. 이메일을 확인해주세요.';
+    }
+    if (error.contains('User already registered')) {
+      return '이미 가입된 이메일입니다.';
+    }
+    if (error.contains('Password should be at least')) {
+      return '비밀번호는 6자 이상이어야 합니다.';
+    }
+    return error;
   }
 
   @override

--- a/lib/ui/auth/widgets/login_screen.dart
+++ b/lib/ui/auth/widgets/login_screen.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../data/services/auth_service.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _isLoading = false;
+  bool _isSignUp = false;
+  String? _name;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleEmailAuth() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
+
+    final authService = context.read<AuthService>();
+    String? errorMessage;
+
+    if (_isSignUp) {
+      errorMessage = await authService.signUpWithEmail(
+        email: _emailController.text,
+        password: _passwordController.text,
+        name: _name,
+      );
+    } else {
+      errorMessage = await authService.signInWithEmail(
+        email: _emailController.text,
+        password: _passwordController.text,
+      );
+    }
+
+    setState(() => _isLoading = false);
+
+    if (errorMessage != null && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(errorMessage)),
+      );
+    }
+  }
+
+  Future<void> _handleSocialAuth(
+      Future<String?> Function() signInMethod) async {
+    setState(() => _isLoading = true);
+
+    final errorMessage = await signInMethod();
+
+    setState(() => _isLoading = false);
+
+    if (errorMessage != null && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(errorMessage)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isSignUp ? '회원가입' : '로그인'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (_isSignUp) ...[
+                TextFormField(
+                  decoration: const InputDecoration(
+                    labelText: '이름',
+                    border: OutlineInputBorder(),
+                  ),
+                  onChanged: (value) => _name = value,
+                ),
+                const SizedBox(height: 16),
+              ],
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: '이메일',
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.emailAddress,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '이메일을 입력해주세요.';
+                  }
+                  if (!value.contains('@')) {
+                    return '올바른 이메일 형식이 아닙니다.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(
+                  labelText: '비밀번호',
+                  border: OutlineInputBorder(),
+                ),
+                obscureText: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '비밀번호를 입력해주세요.';
+                  }
+                  if (value.length < 6) {
+                    return '비밀번호는 6자 이상이어야 합니다.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _isLoading ? null : _handleEmailAuth,
+                child: Text(_isSignUp ? '회원가입' : '로그인'),
+              ),
+              const SizedBox(height: 16),
+              TextButton(
+                onPressed: _isLoading
+                    ? null
+                    : () => setState(() => _isSignUp = !_isSignUp),
+                child: Text(_isSignUp ? '이미 계정이 있나요? 로그인' : '계정이 없나요? 회원가입'),
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                '소셜 로그인',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _isLoading
+                    ? null
+                    : () => _handleSocialAuth(
+                          context.read<AuthService>().signInWithKakao,
+                        ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFFEE500),
+                  foregroundColor: Colors.black87,
+                ),
+                child: const Text('카카오로 계속하기'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _isLoading
+                    ? null
+                    : () => _handleSocialAuth(
+                          context.read<AuthService>().signInWithGoogle,
+                        ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.white,
+                  foregroundColor: Colors.black87,
+                ),
+                child: const Text('Google로 계속하기'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/auth/widgets/my_page_screen.dart
+++ b/lib/ui/auth/widgets/my_page_screen.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../data/services/auth_service.dart';
+import 'login_screen.dart';
+
+class MyPageScreen extends StatelessWidget {
+  const MyPageScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final authService = context.watch<AuthService>();
+    final user = authService.currentUser;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('마이페이지'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (user != null) ...[
+              Text(
+                '이메일: ${user.email}',
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 32),
+            ],
+            ElevatedButton(
+              onPressed: () async {
+                await context.read<AuthService>().signOut();
+                if (context.mounted) {
+                  Navigator.of(context).pushAndRemoveUntil(
+                    MaterialPageRoute(builder: (_) => const LoginScreen()),
+                    (route) => false,
+                  );
+                }
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.red,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('로그아웃'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Supabase 기반 이메일/비밀번호, 구글, 카카오 소셜 로그인 기능을 Flutter 앱에 통합하였습니다.
- 사용자 인증 상태를 관리하는 AuthService 및 UserModel을 도입하였고, Provider 기반 DI 구조를 적용했습니다.
- 로그인/회원가입/소셜 로그인/로그아웃 UI 및 예외 메시지 한글화, UX 개선을 반영했습니다.
- 마이페이지(내 정보) 화면을 추가하여, 현재 로그인된 이메일 표시 및 로그아웃 기능을 제공합니다.
- BottomNavigationBar 구조를 개선하여, 홈/독서목록/마이페이지 탭을 제공합니다.
- 인증 실패, 이메일 미인증, 중복 가입 등 주요 에러 메시지를 사용자 친화적으로 안내합니다.
- Supabase MCP 연동 및 소셜 로그인 리디렉션, 동의항목 관련 가이드도 문서화하였습니다.

주요 변경 파일:
- lib/data/services/auth_service.dart
- lib/domain/models/user_model.dart
- lib/ui/auth/widgets/login_screen.dart
- lib/ui/auth/widgets/my_page_screen.dart
- lib/main.dart